### PR TITLE
Cap boto3 to <1.38 for aiobotocore compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["python-decouple>=3.8", "boto3"]
+dependencies = ["python-decouple>=3.8", "boto3>=1.34,<1.38"]
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
Fixes #6.

`boto3` had no version constraint, so pip pulls `boto3` and `botocore` to the newest PyPI release whenever this package is installed at runtime. Anything in the same env that uses `aiobotocore` then breaks, because `aiobotocore` pins `botocore` to a narrow range. In Home Assistant that shows up as Cloudflare R2, IDrive e2, and Nice G.O. failing to set up after someone opens the HomeLink config flow.

`>=1.34,<1.38` keeps pip inside what `aiobotocore 2.21.x` accepts. Bump it later when HA is on `aiobotocore 3.x`.