### PR TITLE
Add repository url to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ asyncio_default_fixture_loop_scope = "function"
 [project.urls]
 Homepage = "https://www.homelink.com/"
 Issues = "https://www.homelink.com/support"
+Repository = "https://github.com/Gentex-Corporation/homelink-integration-api"
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
Per feedback from a Home Assistant AI review, we are adding a repository url to `pyproject.toml`. This doesn't warrant a version bump, but will be added to a future release.