### PR TITLE
Replace pyOpenSSL with cryptography for CSR generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ multidict==6.1.0
 paho-mqtt==2.1.0
 propcache==0.2.0
 pycparser==2.22
-pyOpenSSL==25.0.0
 python-dateutil==2.9.0.post0
 python-decouple==3.8
 s3transfer==0.11.4

--- a/src/homelink/mqtt_util.py
+++ b/src/homelink/mqtt_util.py
@@ -1,4 +1,7 @@
-from OpenSSL import crypto
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 import re
 from homelink.settings import (
     MQTT_ROOT_CA,
@@ -28,18 +31,19 @@ async def generate_csr():
         cert_data = await response.text()
         if response.status != 200 or "error" in cert_data:
             raise Exception("Failed to get root certificate")
-    key = crypto.PKey()
-    key.generate_key(crypto.TYPE_RSA, MQTT_PRIVATE_KEY_SIZE)
-    key_pem = crypto.dump_privatekey(crypto.FILETYPE_PEM, key).decode("utf-8")
-    bytes_private_key = key_pem.encode("utf-8")
-
-    csr = crypto.X509Req()
-    csr.get_subject().CN = "gentex"
-    csr.set_pubkey(key)
-    csr.sign(key, "sha512")
-
-    csr_pem = crypto.dump_certificate_request(crypto.FILETYPE_PEM, csr).decode(
-        encoding="utf-8"
+    key = rsa.generate_private_key(public_exponent=65537, key_size=MQTT_PRIVATE_KEY_SIZE)
+    bytes_private_key = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
     )
+
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "gentex")]))
+        .sign(key, hashes.SHA512())
+    )
+
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM).decode(encoding="utf-8")
 
     return bytes_private_key, format_csr(csr_pem)


### PR DESCRIPTION
## Why

pyOpenSSL 26.3.0 (released June 2026) removed the long-deprecated `OpenSSL.crypto.X509Req` and `OpenSSL.crypto.dump_certificate_request` APIs. `homelink.mqtt_util.generate_csr` uses both, so with pyOpenSSL 26.3.0 installed, CSR generation fails with `AttributeError` and the MQTT connection can never be established.

This currently blocks Home Assistant from upgrading to pyOpenSSL 26.3.0 / cryptography 49.0.0 without breaking the `gentex_homelink` integration (see the deprecation notes in the [pyOpenSSL changelog](https://github.com/pyca/pyopenssl/blob/main/CHANGELOG.rst)).

## What

Migrates key and CSR generation in `src/homelink/mqtt_util.py` from pyOpenSSL to the `cryptography` package APIs, which is the replacement pyOpenSSL's own deprecation messages recommend. The output is functionally identical:

- Private key: RSA (`MQTT_PRIVATE_KEY_SIZE` bits), PEM-encoded PKCS#8 (same `-----BEGIN PRIVATE KEY-----` format `dump_privatekey` produced)
- CSR: subject `CN=gentex`, signed with SHA-512, PEM-encoded (`format_csr` is unchanged)

Since this was the only pyOpenSSL usage in the package, the `pyOpenSSL` pin is removed from `requirements.txt` (`cryptography` was already listed there). The `cryptography` APIs used here (`rsa.generate_private_key`, `CertificateSigningRequestBuilder`) have been stable for many years, so this works with both old and new cryptography versions — no minimum version bump is needed.

## Verification

Ran `generate_csr` with a mocked root CA download and validated the result with `cryptography`: the CSR signature is valid, subject CN is `gentex`, signature hash is SHA-512, the CSR public key matches the generated private key, and the key PEM header is unchanged.